### PR TITLE
OPS-190 Disable 0-run workflows

### DIFF
--- a/.github/workflows/disabled/test.yml
+++ b/.github/workflows/disabled/test.yml
@@ -1,3 +1,5 @@
+# DISABLED by OPS-190 on 2026-04-20 — workflow had zero runs in GitHub history when audited. Moved to .github/workflows/disabled/ so GitHub Actions no longer parses it (suppresses deprecated-action warnings and reduces noise).
+# To restore: move this file back to .github/workflows/ and update pinned action versions to current standards (see cube-web3/shared-workflows).
 name: test
 
 on: workflow_dispatch


### PR DESCRIPTION
## Summary
Move workflows with **zero runs** in GitHub history to `.github/workflows/disabled/` to suppress deprecated-action warnings. Each moved file has a 2-line header explaining the disable and how to restore.

No active CI changes — all moved workflows were never executed.

Part of OPS-190 org-wide cleanup ahead of GitHubs 2026-06-02 Node-20 deprecation cutoff.

## Test plan
- [ ] No CI should trigger on this PR (target workflows are disabled by this same PR)
- [ ] Confirm org-wide deprecation-warning count drops after merge

_Written by Claude Code_